### PR TITLE
region checker added!

### DIFF
--- a/aws-s3-size.sh
+++ b/aws-s3-size.sh
@@ -2977,7 +2977,14 @@ do
 			feed_write_log="command: aws cloudwatch get-metric-statistics --namespace AWS/S3 --start-time "$timestamp_start" --end-time "$timestamp_end" --period "$timestamp_period" --statistics Average --metric-name BucketSizeBytes --dimensions Name=BucketName,Value="$bucket_name" Name=StorageType,Value="$storage_type_line" --profile "$cli_profile_line_strip" "
 			fnWriteLog ${LINENO} "$feed_write_log"
 			fnWriteLog ${LINENO} ""
-			bucket_size_json_results="$(aws cloudwatch get-metric-statistics --namespace AWS/S3 --start-time "$timestamp_start" --end-time "$timestamp_end" --period "$timestamp_period" --statistics Average --metric-name BucketSizeBytes --dimensions Name=BucketName,Value="$bucket_name" Name=StorageType,Value="$storage_type_line" --profile "$cli_profile_line_strip")"
+			region_specific=$(aws s3api get-bucket-location --bucket $bucket_name --profile "$cli_profile_line_strip"  | jq -r '.LocationConstraint')
+			# region checker
+			fnWriteLog "region: " ${region_specific} 
+			if [ $region_specific == "null" ]; then
+				bucket_size_json_results="$(aws cloudwatch get-metric-statistics --namespace AWS/S3 --start-time "$timestamp_start" --end-time "$timestamp_end" --period "$timestamp_period" --statistics Average --metric-name BucketSizeBytes --dimensions Name=BucketName,Value="$bucket_name" Name=StorageType,Value="$storage_type_line" --profile "$cli_profile_line_strip")"
+			else
+				bucket_size_json_results="$(aws cloudwatch get-metric-statistics --namespace AWS/S3 --start-time "$timestamp_start" --end-time "$timestamp_end" --period "$timestamp_period" --statistics Average --metric-name BucketSizeBytes --dimensions Name=BucketName,Value="$bucket_name" Name=StorageType,Value="$storage_type_line" --profile "$cli_profile_line_strip" --region "$region_specific")"
+			fi
             #
             # check for errors from the AWS API  
             if [ "$?" -ne 0 ]


### PR DESCRIPTION
# Description

Region checker

in big projects the script miss to pull data from another regions, already add a region checker and exception handling when some buckets have the "null" attribute.



Fixes # (issue)

return all buckets sizes without putting region.

## Type of change

- [x ] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?

already test all the possibility  regarding region outputs via the awscli, all working right.



**Test Configuration**:
* AWS CLI version: aws-cli/1.16.88 Python/2.7.15 Linux/5.0.5-200.fc29.x86_64 botocore/1.12.128
* jq version: 1.5
* bash version: 4.4.23(1)
* local Linux/EC2/both: fedora(local),ubuntu ami, jenkins(ubuntu bash)
* Distribution: fedora,ubuntu,debian

# Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
